### PR TITLE
added libopenjp2-7 for necessary dependencies

### DIFF
--- a/joinmarket.md
+++ b/joinmarket.md
@@ -13,7 +13,7 @@
 * With user "admin", install necessary dependencies
 
 ```
-$ sudo apt-get install python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev libssl-dev libatlas3-base
+$ sudo apt-get install python-virtualenv curl python3-dev python3-pip build-essential automake pkg-config libtool libgmp-dev libltdl-dev libssl-dev libatlas3-base libopenjp2-7
 ```
 
 #### Create data directory


### PR DESCRIPTION
Added libopenjp2-7 since it is needed to run  ob-watcher if matplotlib is installed. https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/738